### PR TITLE
QuickTune: moved to more conventional class handling

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -259,6 +259,9 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if HAL_BUTTON_ENABLED
     SCHED_TASK_CLASS(AP_Button,            &copter.button,              update,           5, 100, 168),
 #endif
+#if AP_QUICKTUNE_ENABLED
+    SCHED_TASK(update_quicktune,       40, 100, 171),
+#endif
 };
 
 void Copter::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
@@ -806,6 +809,18 @@ void Copter::update_altitude()
     }
 #endif
 }
+
+#if AP_QUICKTUNE_ENABLED
+/*
+  update AP_Quicktune object. We pass the supports_quicktune() method
+  in so that quicktune can detect if the user changes to a
+  non-quicktune capable mode while tuning and the gains can be reverted
+ */
+void Copter::update_quicktune(void)
+{
+    quicktune.update(flightmode->supports_quicktune());
+}
+#endif
 
 // vehicle specific waypoint info helpers
 bool Copter::get_wp_distance_m(float &distance) const

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -495,7 +495,7 @@ private:
 #endif
 
 #if AP_QUICKTUNE_ENABLED
-    AP_Quicktune *quicktune;
+    AP_Quicktune quicktune;
 #endif
 
     // System Timers
@@ -726,6 +726,9 @@ private:
     bool get_wp_bearing_deg(float &bearing) const override;
     bool get_wp_crosstrack_error_m(float &xtrack_error) const override;
     bool get_rate_ef_targets(Vector3f& rate_ef_targets) const override;
+#if AP_QUICKTUNE_ENABLED
+    void update_quicktune(void);
+#endif
 
     // Attitude.cpp
     void update_throttle_hover();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -496,7 +496,7 @@ const AP_Param::Info Copter::var_info[] = {
 #if AP_QUICKTUNE_ENABLED == ENABLED
     // @Group: QUIK_
     // @Path: ../libraries/AP_Quicktune/AP_Quicktune.cpp
-    GOBJECTPTR(quicktune, "QUIK_",  AP_Quicktune),
+    GOBJECT(quicktune, "QUIK_",  AP_Quicktune),
 #endif
 
     // @Group: ATC_

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -651,7 +651,7 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
 #endif
 #if AP_QUICKTUNE_ENABLED
     case AUX_FUNC::QUICKTUNE:
-        do_aux_function_quicktune(ch_flag);
+        copter.quicktune.update_switch_pos(ch_flag);
         break;
 #endif
 
@@ -690,29 +690,6 @@ void RC_Channel_Copter::do_aux_function_change_force_flying(const AuxSwitchPos c
         break;
     }
 }
-
-#if AP_QUICKTUNE_ENABLED
-// called on any Quicktune Aux function change
-void RC_Channel_Copter::do_aux_function_quicktune(const AuxSwitchPos ch_flag)
-{
-    if (copter.quicktune == nullptr && !copter.arming.is_armed()) {
-        //first call, allocate quicktune object
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Quicktune: Initialised.");
-        copter.quicktune = NEW_NOTHROW AP_Quicktune();
-        if (copter.quicktune == nullptr) {
-            // Can't use BoardConfig error as this might happen while flying.
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Quicktune: unable to allocate.");
-            return;
-        }
-        AP_Param::load_object_from_eeprom(copter.quicktune, copter.quicktune->var_info);
-    } else if (copter.quicktune == nullptr && copter.arming.is_armed()){
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Quicktune: Must be disarmed to initialise.");
-    }
-    if (copter.quicktune != nullptr) {
-        copter.quicktune->update_switch_pos(ch_flag);
-    }
-}
-#endif
 
 // save_trim - adds roll and pitch trims from the radio to ahrs
 void Copter::save_trim()

--- a/ArduCopter/RC_Channel.h
+++ b/ArduCopter/RC_Channel.h
@@ -20,9 +20,6 @@ private:
                                      const AuxSwitchPos ch_flag);
     void do_aux_function_change_air_mode(const AuxSwitchPos ch_flag);
     void do_aux_function_change_force_flying(const AuxSwitchPos ch_flag);
-#if AP_QUICKTUNE_ENABLED
-    void do_aux_function_quicktune(const AuxSwitchPos ch_flag);
-#endif
 
     // called when the mode switch changes position:
     void mode_switch_changed(modeswitch_pos_t new_pos) override;

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -425,12 +425,6 @@ void Copter::update_flight_mode()
 #endif
 
     flightmode->run();
-
-#if AP_QUICKTUNE_ENABLED
-    if (quicktune != nullptr && flightmode->supports_quicktune()) {
-        quicktune->update();
-    }
-#endif
 }
 
 // exit_mode - high level call to organise cleanup as a flight mode is exited

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -139,6 +139,9 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if AC_PRECLAND_ENABLED
     SCHED_TASK(precland_update, 400, 50, 160),
 #endif
+#if AP_QUICKTUNE_ENABLED
+    SCHED_TASK(update_quicktune, 40, 100, 163),
+#endif
 };
 
 void Plane::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
@@ -976,6 +979,18 @@ void Plane::precland_update(void)
 #else
     return g2.precland.update(0, false);
 #endif
+}
+#endif
+
+#if AP_QUICKTUNE_ENABLED
+/*
+  update AP_Quicktune object. We pass the supports_quicktune() method
+  in so that quicktune can detect if the user changes to a
+  non-quicktune capable mode while tuning and the gains can be reverted
+ */
+void Plane::update_quicktune(void)
+{
+    quicktune.update(control_mode->supports_quicktune());
 }
 #endif
 

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -424,11 +424,6 @@ void Plane::stabilize()
 #endif
     } else {
         plane.control_mode->run();
-#if AP_QUICKTUNE_ENABLED
-        if (plane.quicktune != nullptr && control_mode->supports_quicktune()) {
-            plane.quicktune->update();
-        }
-#endif
     }
 
     /*

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1000,7 +1000,7 @@ const AP_Param::Info Plane::var_info[] = {
 #if AP_QUICKTUNE_ENABLED == ENABLED
     // @Group: QUIK_
     // @Path: ../libraries/AP_Quicktune/AP_Quicktune.cpp
-    GOBJECTPTR(quicktune, "QUIK_",  AP_Quicktune),
+    GOBJECT(quicktune, "QUIK_",  AP_Quicktune),
 #endif
     
     AP_VAREND

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -307,7 +307,7 @@ private:
 #endif
 
 #if AP_QUICKTUNE_ENABLED
-    AP_Quicktune *quicktune;
+    AP_Quicktune quicktune;
 #endif
     
     // This is the state of the flight control system
@@ -844,6 +844,10 @@ private:
        terrain_bitmask bitmask;
     };
     static const TerrainLookupTable Terrain_lookup[];
+#endif
+
+#if AP_QUICKTUNE_ENABLED
+    void update_quicktune(void);
 #endif
 
     // Attitude.cpp

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -442,7 +442,7 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
 
 #if AP_QUICKTUNE_ENABLED
     case AUX_FUNC::QUICKTUNE:
-        do_aux_function_quicktune(ch_flag);
+        plane.quicktune.update_switch_pos(ch_flag);
         break;
 #endif
 
@@ -452,26 +452,3 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
 
     return true;
 }
-
-#if AP_QUICKTUNE_ENABLED
-// called on any Quicktune Aux function change
-void RC_Channel_Plane::do_aux_function_quicktune(const AuxSwitchPos ch_flag)
-{
-    if (plane.quicktune == nullptr && !plane.arming.is_armed()) {
-        //first call, allocate quicktune object
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Quicktune: Initialised.");
-        plane.quicktune = NEW_NOTHROW AP_Quicktune();
-        if (plane.quicktune == nullptr) {
-            // Can't use BoardConfig error as this might happen while flying.
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Quicktune: unable to allocate.");
-            return;
-        }
-        AP_Param::load_object_from_eeprom(plane.quicktune, plane.quicktune->var_info);
-    } else if (plane.quicktune == nullptr && plane.arming.is_armed()){
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Quicktune: Must be disarmed to initialise.");
-    }
-    if (plane.quicktune != nullptr) {
-        plane.quicktune->update_switch_pos(ch_flag);
-    }
-}
-#endif

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -30,9 +30,6 @@ private:
     void do_aux_function_soaring_3pos(AuxSwitchPos ch_flag);
 
     void do_aux_function_flare(AuxSwitchPos ch_flag);
-#if AP_QUICKTUNE_ENABLED
-    void do_aux_function_quicktune(const AuxSwitchPos ch_flag);
-#endif
 };
 
 class RC_Channels_Plane : public RC_Channels

--- a/libraries/AP_Quicktune/AP_Quicktune.h
+++ b/libraries/AP_Quicktune/AP_Quicktune.h
@@ -26,7 +26,7 @@ public:
     // Parameter block
     static const struct AP_Param::GroupInfo var_info[];
 
-    void update();
+    void update(bool mode_supports_quicktune);
     void update_switch_pos(const RC_Channel::AuxSwitchPos ch_flag);
 
 private:
@@ -122,7 +122,6 @@ private:
     float slew_target;
     uint8_t slew_steps;
     float slew_delta;
-    uint32_t last_update;
     SwitchPos sw_pos; //Switch pos to be set by aux func
     bool need_restore;
     float param_saved[uint8_t(Param::END)]; //Saved values of the parameters
@@ -151,7 +150,7 @@ private:
     const char* get_axis_name(AxisName axis);
     void Write_QUIK(float SRate, float Gain, Param param);
 
-    AC_AttitudeControl &attitude_control = *AC_AttitudeControl::get_singleton();
+    void abort_tune(void);
 };
 
 #endif  // AP_QUICKTUNE_ENABLED


### PR DESCRIPTION
put AP_Quicktune as a normal object in copter, and added auto-abort on mode change or attitude error
